### PR TITLE
Remove node example removes line instead of adding empty statement

### DIFF
--- a/example-transformers/remove-node/transformed/source.js
+++ b/example-transformers/remove-node/transformed/source.js
@@ -1,2 +1,1 @@
-;
 console.log(lodash);

--- a/example-transformers/remove-node/transformer.ts
+++ b/example-transformers/remove-node/transformer.ts
@@ -4,7 +4,7 @@ const transformer: ts.TransformerFactory<ts.SourceFile> = context => {
   return sourceFile => {
     const visitor = (node: ts.Node): ts.Node => {
       if (ts.isImportDeclaration(node)) {
-        return ts.createEmptyStatement();
+        return undefined;
       }
 
       return ts.visitEachChild(node, visitor, context);


### PR DESCRIPTION
## 🗒️ Summary
`remove-node` example removes the statement instead of replacing it with an `EmptyStatement`

Fixes #10

#### ⏪ Transformed Code Before
```javascript
;
console.log(lodash);
```

#### ⏩ Transformed Code After
```javascript
console.log(lodash);
```

## 🏖️ Context
Align transformer examples with documentation in `README.md` (https://github.com/madou/typescript-transformer-handbook/commit/732ea93d80e50773ce3452738b713c7f156f7988)

## 🔬 How has been Tested
`npx ttsc` under `/example-transformers/remove-node`
 